### PR TITLE
Add start/stop/ready/logs targets and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Demonstrates how to use AWS SAM with LocalStack to create a Lambda function and 
 
 ## Prerequisites
 
-* LocalStack with the [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
+* A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
+* [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 * Docker
 * `make`
 * [`awslocal`](https://github.com/localstack/awscli-local)
 * [`samlocal`](https://github.com/localstack/aws-sam-cli-local)
 * NodeJS 18.x
 * [`ulid`](https://www.npmjs.com/package/ulid)
-* A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,20 @@ Demonstrates how to use AWS SAM with LocalStack to create a Lambda function and 
 
 ## Prerequisites
 
-* LocalStack
+* LocalStack with the [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 * Docker
 * `make`
 * [`awslocal`](https://github.com/localstack/awscli-local)
 * [`samlocal`](https://github.com/localstack/aws-sam-cli-local)
 * NodeJS 18.x
 * [`ulid`](https://www.npmjs.com/package/ulid)
+* A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
 
 ## Installing
 
 Setup [Serverless Application Model (SAM)](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) and [AWS SAM CLI Local](https://github.com/localstack/aws-sam-cli-local) on your local machine. We also recommend using NodeJS 14.x alongside a [Node Version Manager](https://github.com/nvm-sh/nvm) to manage your NodeJS versions.
 
-Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```shell
 export LOCALSTACK_AUTH_TOKEN=<your-auth-token>

--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ Demonstrates how to use AWS SAM with LocalStack to create a Lambda function and 
 
 Setup [Serverless Application Model (SAM)](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) and [AWS SAM CLI Local](https://github.com/localstack/aws-sam-cli-local) on your local machine. We also recommend using NodeJS 14.x alongside a [Node Version Manager](https://github.com/nvm-sh/nvm) to manage your NodeJS versions.
 
-Create a file named `.env-local` and put your LocalStack Auth Token in it. It is ignored by gitignore.
+Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+
 ```shell
-export LOCALSTACK_AUTH_TOKEN=<your-token>>
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
+make start
+make ready
 ```
 
-Start LocalStack via:
-
-```sh 
-localstack start -d
+Optionally, create a file named `.env-local` to persist your token (it is ignored by gitignore):
+```shell
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
 ```
 
 ## Deploy the application

--- a/makefile
+++ b/makefile
@@ -1,7 +1,27 @@
 -include .env-local
 -include ./devops-tooling/envs.makefile
 
+export AWS_ACCESS_KEY_ID ?= test
+export AWS_SECRET_ACCESS_KEY ?= test
+export AWS_DEFAULT_REGION=us-east-1
+SHELL := /bin/bash
 
+usage:		## Show this help
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+start:		## Start LocalStack
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+
+stop:		## Stop LocalStack
+	@localstack stop
+
+ready:		## Wait until LocalStack is ready
+	@echo Waiting on the LocalStack container...
+	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+
+logs:		## Save the logs in a separate file
+	@localstack logs > logs.txt
 
 install:
 	npm install --save ulid


### PR DESCRIPTION
## Summary
- Add `start`, `stop`, `ready`, `logs` targets to Makefile with `LOCALSTACK_AUTH_TOKEN` guard
- Update README to use `make start` pattern for LocalStack startup